### PR TITLE
v1.1.0リリース準備: UPMパッケージバージョン更新

### DIFF
--- a/src/DotNetG2P.Core/package.json
+++ b/src/DotNetG2P.Core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.dotnetg2p.core",
   "displayName": "DotNetG2P",
-  "version": "0.1.0",
+  "version": "1.1.0",
   "unity": "2021.2",
   "description": "Japanese Grapheme-to-Phoneme (G2P) library for Unity. OpenJTalk-compatible rule-based G2P pipeline with NJD processing, phoneme conversion, and HTS full-context label generation.",
   "keywords": [

--- a/src/DotNetG2P.MeCab/package.json
+++ b/src/DotNetG2P.MeCab/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.dotnetg2p.mecab",
   "displayName": "DotNetG2P.MeCab",
-  "version": "0.1.0",
+  "version": "1.1.0",
   "unity": "2021.2",
   "description": "Pure C# MeCab-compatible morphological analyzer for DotNetG2P. No external native dependencies. Apache-2.0 licensed.",
   "keywords": [
@@ -13,7 +13,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "com.dotnetg2p.core": "0.1.0"
+    "com.dotnetg2p.core": "1.1.0"
   },
   "author": {
     "name": "ayutaz"


### PR DESCRIPTION
## Summary
- UPMパッケージバージョンを `0.1.0` → `1.1.0` に更新
  - `com.dotnetg2p.core` (package.json)
  - `com.dotnetg2p.mecab` (package.json + 依存バージョン)

## リリース手順
1. このPRをマージ
2. GitHub Actions の Release ワークフローを手動実行（version: `1.1.0`）
   - NuGetパッケージのバージョンはワークフロー側で `-p:PackageVersion` により設定される
   - タグ `v1.1.0` の作成・GitHub Release・NuGet push が自動実行される

## Test plan
- [x] UPMバージョン整合性確認（Core・MeCab・依存バージョンが全て1.1.0）
- [ ] マージ後にReleaseワークフローで `1.1.0` を指定して実行