### PR TITLE
Copyright年号を2026に統一

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Copyright>Copyright (c) 2025 ayutaz</Copyright>
+    <Copyright>Copyright (c) 2026 ayutaz</Copyright>
 
     <!-- SourceLink -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/LICENSE
+++ b/LICENSE
@@ -176,7 +176,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2025 ayutaz
+   Copyright 2026 ayutaz
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary
- `Directory.Build.props` と `LICENSE` のCopyright年号を2025→2026に修正

## Test plan
- [ ] ビルドが通ることを確認